### PR TITLE
Add refresh token endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ require('dotenv').config();
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import express from 'express';
-import dotenv from 'dotenv';
 
 import publicApi from './routes/public-api';
 import securedApi from './routes/secured-api';

--- a/src/routes/public-api.ts
+++ b/src/routes/public-api.ts
@@ -58,7 +58,7 @@ router.post('/login', asyncHandler(async (req, res) => {
                 username,
             };
             const token = jwt.sign(payload, Jwt.SECRET, {
-                expiresIn: '7d'
+                expiresIn: Jwt.DURATION,
             });
 
             const usr = await UserService.findByUsername(username);

--- a/src/routes/secured/token.ts
+++ b/src/routes/secured/token.ts
@@ -1,0 +1,34 @@
+import express, { Response } from 'express';
+import { asyncHandler } from '../../middleware/async-handler';
+import { RequestWithUser } from '../../interfaces/requests';
+import { MovnetError } from '../../middleware/MovnetError';
+import { Jwt } from '../../utils/Jwt';
+import jwt from 'jsonwebtoken';
+import ResponseValue from '../../utils/ResponseValue';
+
+
+module.exports = (router: express.Router) => {
+    /**
+     * Refreshes the token
+     */
+    router.get('/token', asyncHandler(async (req: RequestWithUser, res: Response) => {
+        if(req.user === undefined) {
+            throw new MovnetError(500, 'Could not find user data');
+        }
+
+        const payload: Jwt.Payload = {
+            username: req.user.username,
+        };
+
+        const token = jwt.sign(payload, Jwt.SECRET, {
+            expiresIn: Jwt.DURATION,
+        });
+
+        const { password, ...user } = req.user;
+
+        res.status(200).json(new ResponseValue(true, {
+            token,
+            user,
+        }));
+    }));
+};

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -46,8 +46,6 @@ export class UserService {
                 throw new MovnetError(500, `${username} not found`);
             }
 
-            logger.debug(`${username} ${password}`);
-
             return hasher.verify(user.password, password);
         } catch(err) {
             throw new MovnetError(500, 'Error with validation');

--- a/src/utils/Jwt.ts
+++ b/src/utils/Jwt.ts
@@ -18,5 +18,10 @@ export namespace Jwt {
      * Secret that the JWT gets encrypted with
      */
     // tslint:disable-next-line
-    export const SECRET = 'fïoîGsÒÇïÔ£Ó¯ã9ÂVçò¤9ëkeÍ¥aì®gÛcôÙv§m¨Ec«Ø¨DÑûXÔÃrâ½ËòKrMWìz¢ûdÑ©°iëRÈu¹÷sf55r4aÒ¨Óî«rcú¼Ö7ÃÊQñbyrÄ°ÜSÕHÈóäæCüg²ªhÂ©ÿáQÑ´«¥ßYCö²';    
+    export const SECRET = 'fïoîGsÒÇïÔ£Ó¯ã9ÂVçò¤9ëkeÍ¥aì®gÛcôÙv§m¨Ec«Ø¨DÑûXÔÃrâ½ËòKrMWìz¢ûdÑ©°iëRÈu¹÷sf55r4aÒ¨Óî«rcú¼Ö7ÃÊQñbyrÄ°ÜSÕHÈóäæCüg²ªhÂ©ÿáQÑ´«¥ßYCö²';
+    
+    /**
+     * Duration of the token. Expires in 30 days.
+     */
+    export const DURATION = '30d';
 }


### PR DESCRIPTION
Tokens can be refreshed so the user doesn't have to login again. The duration
of the token is now 30 days instead of 7 so if they don't use the app they
won't have to login again.