### PR TITLE
Add success: false to errors

### DIFF
--- a/src/middleware/error-handler.ts
+++ b/src/middleware/error-handler.ts
@@ -18,12 +18,14 @@ export function errorHandler(error: MovnetError, req: Request, res: Response, ne
 
     if(error.getDetails()) {
         res.status(error.getStatus()).json({
+            success: false,
             status: error.getStatus(),
             message: error.getMessage(),
             details: error.getDetails(),
         });
     } else {
         res.status(error.getStatus()).json({
+            success: false,
             status: error.getStatus(),
             message: error.getMessage(),
         });


### PR DESCRIPTION
Add `success: false` to error values to keep it consistent with the rest of the API.