### PR TITLE
formatted date time

### DIFF
--- a/src/models/movie.ts
+++ b/src/models/movie.ts
@@ -31,7 +31,7 @@ export class Movie {
     }
 
     public static async all(){
-      return await knex('Movie').select();
+      return await knex('Movie').select().orderBy('name', 'asc');
     }
 
     public static async search(genre: string, name: string) {
@@ -42,7 +42,7 @@ export class Movie {
         if(name){
           this.where('name', 'like', `%${name}%`);
         }
-      });
+      }).orderBy('name', 'asc');
     }
 
     // Variable names should match up with database column

--- a/src/models/showtime.ts
+++ b/src/models/showtime.ts
@@ -37,10 +37,9 @@ export class Showtime {
           date_time = new Date(date_time);
           let startDate = new Date(date_time.setHours(0,0,0));
           let endDate = new Date(date_time.setHours(23,59,59));
-          console.log(startDate, endDate);
           this.whereBetween('date_time', [ startDate, endDate ]);
         }
-      });
+      }).orderBy('date_time', 'desc');
     }
 
     // Variable names should match up with database column

--- a/src/models/theater.ts
+++ b/src/models/theater.ts
@@ -24,11 +24,11 @@ export class Theater {
     }
 
     public static async all(){
-      return await knex('Theater').select();
+      return await knex('Theater').select().orderBy('name', 'asc');
     }
 
     public static async search(city: string){
-      return await knex('Theater').where('address', 'like', `%${city}%`);
+      return await knex('Theater').where('address', 'like', `%${city}%`).orderBy('name', 'asc');
     }
 
     // Variable names should match up with database column

--- a/src/services/showtime.ts
+++ b/src/services/showtime.ts
@@ -13,6 +13,18 @@ export class ShowtimeService {
     }
 
     public static async search(theater_id: number, movie_id: number, date_time: Date) {
-      return Showtime.search(theater_id, movie_id, date_time);
+      // perform search
+      let showtimes = await Showtime.search(theater_id, movie_id, date_time);
+
+      // format the date and time for each showtime
+      return showtimes.map((showtime:any) => {
+        // get the date_time as a string (this is easiest way...)
+        let date_time = JSON.stringify(showtime.date_time).replace(/\"/g, '');
+        // first half is always date
+        showtime.date = date_time.split('T')[0];
+        // second half is always time + time zone signifier (Z means UTC), so remove it
+        showtime.time = date_time.split('T')[1].replace('Z', '');
+        return showtime;
+      });
     }
 }


### PR DESCRIPTION
- searching showtimes now returns two additional fields on the Showtime object: `date` and `time`. 
Ex. 
```
{
      "showtime_id": 913,
      "theater_id": 1,
      "date_time": "2019-03-16T08:50:00.000Z",
      "movie_id": 3,
      "cost": 1,
      "date": "2019-03-16",
      "time": "08:50:00.000"
  }
```
- searching showtimes returns a result sorted by date_time, ascending (newer first, older last)
- searching movies returns a result sorted by name, alphabetically
- searching theaters returns a result sorted by name, alphabetically