### PR TITLE
Fix bug with time and sort by ascending

### DIFF
--- a/src/models/showtime.ts
+++ b/src/models/showtime.ts
@@ -39,7 +39,7 @@ export class Showtime {
           let endDate = new Date(date_time.setHours(23,59,59));
           this.whereBetween('date_time', [ startDate, endDate ]);
         }
-      }).orderBy('date_time', 'desc');
+      }).orderBy('date_time', 'asc');
     }
 
     // Variable names should match up with database column

--- a/src/services/showtime.ts
+++ b/src/services/showtime.ts
@@ -21,7 +21,9 @@ export class ShowtimeService {
         // get the date_time as a string (this is easiest way...)
         let date_time = (new Date(JSON.stringify(showtime.date_time).replace(/\"/g, '')));
         let date = date_time.toString().split(' ').slice(0,4).join(' ');
-        let time = date_time.toLocaleTimeString('en-US').split(' ').map((str, index) => index>0 ? str : str.slice(0,4)).join(' ');
+        const timeRegex = /\d+:\d+/; // matches time formats of HH:MM, where the first H could be missing
+        let time = date_time.toLocaleTimeString('en-US').split(' ').map(
+          (str, index) => index>0 ? str : timeRegex.exec(str)![0]).join(' ');
         showtime.date = date;
         showtime.time = time;
         showtime.date_time = date_time.toString();


### PR DESCRIPTION
Times weren't being displayed properly in the showtime, and now they're sorted by ascending order instead of descending.