### PR TITLE
created working route for add user to event

### DIFF
--- a/src/models/participation.ts
+++ b/src/models/participation.ts
@@ -1,4 +1,5 @@
 import { knex } from '../utils/knex';
+import { User } from './user';
 
 /**
  * Models the Participation Schema
@@ -6,7 +7,7 @@ import { knex } from '../utils/knex';
 export class Participation {
 
     /**
-     * Adds a new theater to the database
+     * Adds a new user to an event
      * @param event_id id of event to participate of theater
      * @param username username of participant
      */
@@ -35,11 +36,20 @@ export class Participation {
     /**
      * Gets the users in an event
      */
-    public static async getUsersForEvent(event_id: number) {
+    public static async getUsersForEvent(event_id: number): Promise<User[]> {
       return knex('Participation')
         .select('*')
         .where('event_id', event_id)
         .innerJoin('User', 'Participation.username', '=', 'User.username');
+    }
+
+    public static async addUserstoEvent(event_id: number, usernames: string[]){
+      let result = [];
+      for(let username of usernames){
+        let data = await Participation.add(event_id, username);
+        result.push(data);
+      }
+      return result;
     }
 
     // Variable names should match up with database column

--- a/src/routes/secured/event.ts
+++ b/src/routes/secured/event.ts
@@ -49,4 +49,23 @@ module.exports = (router: express.Router) => {
 
     return res.json(new ResponseValue(true, users));
   }));
+
+  /**
+  * Adds user to an event
+  */
+  router.post('/event/:event_id', asyncHandler(async (req: RequestWithUser, res: Response) => {
+    if(req.user){
+      const event_id = req.params.event_id; // event we're talking about
+      const username = req.user.username;
+      const usernames = req.body.usernames; // usernames of people wanting to add
+      // note: the users to add MUST be friends of the logged in user
+
+      const users = await EventService.addUserstoEvent(event_id, username, usernames);
+
+      return res.json(new ResponseValue(true, users));
+    }
+    else {
+      return res.json(new ResponseValue(false, 'no user da hek'));
+    }
+  }));
 };

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -1,5 +1,7 @@
 import { Event } from '../models/event';
 import { Participation } from '../models/participation';
+import { User } from '../models/user';
+import { Friend } from '../models/friend';
 
 export class EventService {
     /**
@@ -23,7 +25,23 @@ export class EventService {
      * Get's an event's participants
      * @param event_id
      */
-    public static async getUsersForEvent(event_id: number) {
+    public static async getUsersForEvent(event_id: number): Promise<User[]> {
       return Participation.getUsersForEvent(event_id);
+    }
+
+    public static async addUserstoEvent(event_id: number, username: string, usernames: string[]) {
+      // filter out non-friends in case
+      let { confirmed } = await Friend.getFriends(username);
+      // usernames = usernames.filter(uname => {
+      //   return confirmed.some(confirmedFriend => confirmedFriend.username == uname);
+      // });
+
+      // get rid of people already in event
+      let currentParticipants = await EventService.getUsersForEvent(event_id);
+      usernames = usernames.filter(uname => {
+        return !currentParticipants.some(participant => participant.username == uname);
+      });
+
+      return Participation.addUserstoEvent(event_id, usernames);
     }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -318,6 +318,39 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [ "Event" ],
+        "description": "Adds the given list of users to the specified event. Will only add users who are confirmed friends of the user making the request. Will ignore users who are already part of event",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "type": "number",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "usernames",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully added users to event. Returns the participants of the event",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        }
       }
     },
     "/api/movie": {


### PR DESCRIPTION
- added route for adding users to event
- send a list of usernames of people to add
- they must all be confirmed friends to add
- they will not be added if they are not confirmed friends or if they are already participants on the event
- updated swagger docs to reflect changes